### PR TITLE
Fix a bug where xlen larger than 0x7fff was rejected (1.x)

### DIFF
--- a/okio/src/main/java/okio/GzipSource.java
+++ b/okio/src/main/java/okio/GzipSource.java
@@ -127,7 +127,7 @@ public final class GzipSource implements Source {
     if (((flags >> FEXTRA) & 1) == 1) {
       source.require(2);
       if (fhcrc) updateCrc(source.buffer(), 0, 2);
-      int xlen = source.buffer().readShortLe();
+      int xlen = source.buffer().readShortLe() & 0xffff;
       source.require(xlen);
       if (fhcrc) updateCrc(source.buffer(), 0, xlen);
       source.skip(xlen);

--- a/okio/src/test/java/okio/GzipSourceTest.java
+++ b/okio/src/test/java/okio/GzipSourceTest.java
@@ -15,9 +15,11 @@
  */
 package okio;
 
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.CRC32;
-import org.junit.Test;
 
 import static okio.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -180,6 +182,18 @@ public final class GzipSourceTest {
       fail();
     } catch (IOException expected) {
     }
+  }
+
+  @Test public void extraLongXlen() throws Exception {
+    int xlen = 0xffff;
+    Buffer gzippedSource = new Buffer()
+        .write(gzipHeaderWithFlags((byte) 0x04));
+    gzippedSource.writeShort((short) xlen);
+    gzippedSource.write(new byte[xlen]);
+    gzippedSource.write(ByteString.decodeHex("f3c8540400dac59e7903000000"));
+
+    Buffer gunzipped = gunzip(gzippedSource);
+    assertEquals("Hi!", gunzipped.readUtf8());
   }
 
   private ByteString gzipHeaderWithFlags(byte flags) {


### PR DESCRIPTION
Backported from 81bce1a30af244550b0324597720e4799281da7b for 1.x by @xstefank